### PR TITLE
Audit

### DIFF
--- a/src/main/java/wolox/bootstrap/configuration/PersistenceConfig.java
+++ b/src/main/java/wolox/bootstrap/configuration/PersistenceConfig.java
@@ -1,0 +1,8 @@
+package wolox.bootstrap.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class PersistenceConfig { }

--- a/src/main/java/wolox/bootstrap/models/Auditable.java
+++ b/src/main/java/wolox/bootstrap/models/Auditable.java
@@ -21,4 +21,11 @@ public abstract class Auditable {
 	@Temporal(TemporalType.TIMESTAMP)
 	protected Date lastModifiedDate;
 
+	public Date getCreationDate() {
+		return creationDate;
+	}
+
+	public Date getLastModifiedDate() {
+		return lastModifiedDate;
+	}
 }

--- a/src/main/java/wolox/bootstrap/models/Auditable.java
+++ b/src/main/java/wolox/bootstrap/models/Auditable.java
@@ -5,27 +5,23 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class Auditable {
 
 	@CreatedDate
-	@Temporal(TemporalType.TIMESTAMP)
-	protected Date creationDate;
+	protected LocalDateTime creationDate;
 
 	@LastModifiedDate
-	@Temporal(TemporalType.TIMESTAMP)
-	protected Date lastModifiedDate;
+	protected LocalDateTime lastModifiedDate;
 
-	public Date getCreationDate() {
+	public LocalDateTime getCreationDate() {
 		return creationDate;
 	}
 
-	public Date getLastModifiedDate() {
+	public LocalDateTime getLastModifiedDate() {
 		return lastModifiedDate;
 	}
 }

--- a/src/main/java/wolox/bootstrap/models/Auditable.java
+++ b/src/main/java/wolox/bootstrap/models/Auditable.java
@@ -1,0 +1,24 @@
+package wolox.bootstrap.models;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.util.Date;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class Auditable {
+
+	@CreatedDate
+	@Temporal(TemporalType.TIMESTAMP)
+	protected Date creationDate;
+
+	@LastModifiedDate
+	@Temporal(TemporalType.TIMESTAMP)
+	protected Date lastModifiedDate;
+
+}

--- a/src/main/java/wolox/bootstrap/models/User.java
+++ b/src/main/java/wolox/bootstrap/models/User.java
@@ -19,7 +19,7 @@ import java.util.LinkedList;
 
 @Entity
 @Table(name = "users")
-public class User {
+public class User extends Auditable {
 
     private static final String EMPTY_FIELD = "This field cannot be empty.";
 

--- a/src/test/java/wolox/bootstrap/models/UserTest.java
+++ b/src/test/java/wolox/bootstrap/models/UserTest.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.test.context.junit4.SpringRunner;
 import wolox.bootstrap.configuration.PersistenceConfig;
 import wolox.bootstrap.repositories.UserRepository;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest(includeFilters = @Filter(
@@ -59,9 +59,9 @@ public class UserTest {
 
 	@Test
 	public void whenFindByUsername_ThenReturnUserWithCreationDateBeforeToNow() {
-		Date dateAfterSaveUser = new Date();
+		LocalDateTime dateAfterSaveUser = LocalDateTime.now();
 		User receivedUser = userRepository.findByUsername("username").get();
-		Assertions.assertTrue(receivedUser.getCreationDate().before(dateAfterSaveUser));
+		Assertions.assertTrue(receivedUser.getCreationDate().isBefore(dateAfterSaveUser));
 	}
 
 	@Test
@@ -71,7 +71,7 @@ public class UserTest {
 		entityManager.persist(userToBeModified);
 		entityManager.flush();
 		User userAfterModified = userRepository.findByUsername("username").get();
-		Assertions.assertTrue(userAfterModified.getCreationDate().before(userAfterModified.getLastModifiedDate()));
+		Assertions.assertTrue(userAfterModified.getCreationDate().isBefore(userAfterModified.getLastModifiedDate()));
 	}
 
 }

--- a/src/test/java/wolox/bootstrap/models/UserTest.java
+++ b/src/test/java/wolox/bootstrap/models/UserTest.java
@@ -65,7 +65,7 @@ public class UserTest {
 	}
 
 	@Test
-	public void whenFindByUsername_AndModified_ThenReturnUserWithCreationDateBeforeToModifiedDate() {
+	public void whenFindByUsernameAndModifiedName_ThenReturnUserWithCreationDateBeforeToModifiedDate() {
 		User userToBeModified = userRepository.findByUsername("username").get();
 		userToBeModified.setName("modified name");
 		entityManager.persist(userToBeModified);

--- a/src/test/java/wolox/bootstrap/models/UserTest.java
+++ b/src/test/java/wolox/bootstrap/models/UserTest.java
@@ -1,20 +1,26 @@
 package wolox.bootstrap.models;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace.NONE;
-
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.test.context.junit4.SpringRunner;
+import wolox.bootstrap.configuration.PersistenceConfig;
 import wolox.bootstrap.repositories.UserRepository;
+import java.util.Date;
 
 @RunWith(SpringRunner.class)
-@DataJpaTest
+@DataJpaTest(includeFilters = @Filter(
+		type = ASSIGNABLE_TYPE,
+		classes = {PersistenceConfig.class}
+))
 @AutoConfigureTestDatabase(replace = NONE)
 public class UserTest {
 
@@ -48,7 +54,24 @@ public class UserTest {
 		role.setName("ADMIN");
 		user.addToRole(role);
 
-		assertTrue(userRepository.findByUsername("username").get().isInRole(role.getName()));
+		Assertions.assertTrue(userRepository.findByUsername("username").get().isInRole(role.getName()));
+	}
+
+	@Test
+	public void whenFindByUsername_ThenReturnUserWithCreationDateBeforeToNow() {
+		Date dateAfterSaveUser = new Date();
+		User receivedUser = userRepository.findByUsername("username").get();
+		Assertions.assertTrue(receivedUser.getCreationDate().before(dateAfterSaveUser));
+	}
+
+	@Test
+	public void whenFindByUsername_AndModified_ThenReturnUserWithCreationDateBeforeToModifiedDate() {
+		User userToBeModified = userRepository.findByUsername("username").get();
+		userToBeModified.setName("modified name");
+		entityManager.persist(userToBeModified);
+		entityManager.flush();
+		User userAfterModified = userRepository.findByUsername("username").get();
+		Assertions.assertTrue(userAfterModified.getCreationDate().before(userAfterModified.getLastModifiedDate()));
 	}
 
 }


### PR DESCRIPTION
### Summary

* Add configuration class enabling JPA auditing.
* All entities that need to be audited must extend Auditable.
* Auditable allows to know creation date and last modification on Users entity.

### Trello Card

https://trello.com/c/MwMDotgK/80-audit

### Screenshots

Here we have the user entity with the two fields(creation_date , last_modified_date) added for audit.

<img width="1110" alt="Screen Shot 2020-03-24 at 20 46 46" src="https://user-images.githubusercontent.com/44373023/77487277-d0cf4c80-6e10-11ea-9fe5-b2b99f83d1a9.png">


